### PR TITLE
Add scale property to L-system parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                     length and don't draw a line; "+" means: Turn right by a given angle, "-" means:
                     Turn
                     left by the
-                    same angle. The symbol "[" stores the current position and angle, whereas the symbol
+                    same angle. "*" and "/" scale each line by a factor of 2. The symbol "[" stores the current position and angle, whereas the symbol
                     "]" restores the
                     last position and angle, i.e. jumps back to the last "[". Every other character is simply
                     ignored.

--- a/js/Curve.js
+++ b/js/Curve.js
@@ -1,9 +1,10 @@
 class Curve {
-    constructor(axiom, productions, angle, bbox) {
+    constructor(axiom, productions, angle, bbox, scale) {
         this.axiom = axiom;
         this.current_iteration = axiom;
         this.productions = productions;
         this.angle = angle;
+        this.scale = scale;
         this.bbox = bbox;
         this.layer = new Layer();
         console.log(productions)
@@ -12,6 +13,7 @@ class Curve {
     set_axiom(axiom) { this.axiom = axiom; }
     set_productions(productions) { this.productions = productions; }
     set_angle(angle) { this.angle = angle; }
+    set_scale(scale) { this.scale = scale; }
     set_bbox(bbox) { this.bbox = bbox }
     reset_current_iteration() {
         this.current_iteration = this.axiom;
@@ -34,7 +36,7 @@ class Curve {
     get_current_iteration() { return this.current_iteration }
 
     update_view() {
-        this.layer.from_turtle(this.current_iteration, this.angle);
+        this.layer.from_turtle(this.current_iteration, this.angle, this.scale);
         this.layer.fit_to_frame(this.bbox);
     }
 

--- a/js/Layer.js
+++ b/js/Layer.js
@@ -11,7 +11,7 @@ class Layer {
 
     // add_polygon(polygon) { this.polygons = this.polygons.concat(polygon); }
 
-    from_turtle(turtle_string, angle = PI / 2, start_point = new Point(0, 0), start_angle = 0) {
+    from_turtle(turtle_string, angle = PI / 2, scale = 0.5, start_point = new Point(0, 0), start_angle = 0, start_scale = 1) {
         // this.points = this.points.concat(start_point);
         let forward = function (x, y, phi) {
             // hypotenuse = 1
@@ -22,7 +22,7 @@ class Layer {
         }
         this.points = [];
         this.polylines = [];
-        let current_state = new State(start_point, start_angle);
+        let current_state = new State(start_point, start_angle, start_scale);
         let substrings = turtle_string.split(/(\[|\]|f)/g)
         let states = [];
         for (let string of substrings) {
@@ -43,8 +43,9 @@ class Layer {
                     break;
                 default:
                     let polyline = new Polyline();
-                    let state = polyline.coordinates_from_turtle(string, angle, current_state.get_point().clone(), current_state.get_angle());
-                    current_state = new State(state[0], state[1]);
+                    let state = polyline.coordinates_from_turtle(string, angle, scale, current_state.get_point().clone(), current_state.get_angle(), current_state.get_scale());
+                    current_state = new State(state[0], state[1], state[2]);
+                    console.log(current_state);
                     this.polylines = this.polylines.concat(polyline)
                     for (let point of polyline.get_points()) {
                         this.points = this.points.concat(point);

--- a/js/Polyline.js
+++ b/js/Polyline.js
@@ -6,14 +6,15 @@ class Polyline {
     get_points() { return (this.points); }
 
 
-    coordinates_from_turtle(turtle_string, angle = PI / 2, start_point = new Point(0, 0), start_angle = 0) {
+    coordinates_from_turtle(turtle_string, angle = PI / 2, scale = 0.5, start_point = new Point(0, 0), start_angle = 0, start_scale = 1) {
         let current_angle = start_angle;
+        let current_scale = start_scale;
         this.points.push(start_point);
-        let forward = function (x, y, phi) {
+        let forward = function (x, y, phi, scale) {
             // hypotenuse = 1
             // console.log(phi)
-            x = x + cos(phi);
-            y = y + sin(phi);
+            x = x + (cos(phi) * scale);
+            y = y + (sin(phi) * scale);
             return (new Point(x, y));
         }
 
@@ -21,7 +22,7 @@ class Polyline {
             // console.log(character)
             switch (character) {
                 case 'F':
-                    this.points.push(forward(this.points[this.points.length - 1].get_x(), this.points[this.points.length - 1].get_y(), current_angle));
+                    this.points.push(forward(this.points[this.points.length - 1].get_x(), this.points[this.points.length - 1].get_y(), current_angle, current_scale));
                     break;
                 case '+':
                     current_angle += angle;
@@ -29,12 +30,18 @@ class Polyline {
                 case '-':
                     current_angle -= angle;
                     break;
+                case '*':
+                    current_scale /= scale;
+                    break;
+                case '/':
+                    current_scale *= scale;
+                    break;
                 default:
                     // console.log(character);
                     break;
             }
         }
-        return ([this.points[this.points.length - 1].clone(), current_angle]);
+        return ([this.points[this.points.length - 1].clone(), current_angle, current_scale]);
     }
 
     get_bounding_box() {

--- a/js/State.js
+++ b/js/State.js
@@ -1,14 +1,17 @@
 class State {
-    constructor(point, angle) {
+    constructor(point, angle, scale) {
         this.point = point;
         this.angle = angle;
+        this.scale = scale;
     }
 
     get_point() { return (this.point); }
     get_angle() { return (this.angle); }
+    get_scale() { return (this.scale); }
 
     set_point(point) { this.point = point; }
-    set_angel(angle) { this.angle = angle; }
+    set_angle(angle) { this.angle = angle; }
+    set_scale(scale) { this.scale = scale; }
 
-    clone() { return new State(this.point, this.angle); }
+    clone() { return new State(this.point, this.angle, this.scale); }
 }


### PR DESCRIPTION
Before (no scaling factor, can see overlaps):

<img width="1177" height="851" alt="out2" src="https://github.com/user-attachments/assets/fe965b16-1df3-4222-b3b8-c1c7c4d575c0" />


After (scaling factor, avoids overlaps):

<img width="1152" height="838" alt="out1" src="https://github.com/user-attachments/assets/64d49517-7c2a-4211-9876-2f9b233bd634" />
